### PR TITLE
feat(analytics): add GA4 tracking across the site

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,97 @@
+# Google Analytics (GA4)
+
+Property tag: `G-Q30CGRHEZN`, loaded by `src/components/Analytics/GoogleAnalytics.tsx`
+from the root layout. It reports only from the live site — local dev, Vercel
+previews and `/studio` are excluded — and every helper in
+`src/lib/analytics/gtag.ts` no-ops when gtag hasn't loaded.
+
+Event names follow GA4's recommended set wherever one exists. That's what makes
+them land in the built-in reports instead of sitting as unmapped custom events.
+
+## What is collected, and where it shows up in GA
+
+### Reports → Life cycle → Acquisition / Engagement (automatic)
+
+Collected by the tag itself, no code involved: `page_view` (including App Router
+client-side navigation, via Enhanced measurement's history-event tracking),
+`session_start`, `first_visit`, `user_engagement`, `scroll` (90 % depth),
+`click` on outbound links, `file_download`, plus device, geo, language,
+traffic source and landing page.
+
+### Reports → Monetization → Ecommerce purchases / Purchase journey
+
+| Event | Fired from | When |
+| --- | --- | --- |
+| `view_item_list` | `Analytics/TrackListView` via `Blocks/ProductList`, `Blocks/TicketList` | A shop or screening list renders on the page |
+| `select_item` | `ProductList/ProductGrid`, `TicketList/TicketGate` | A product card or ticket card is clicked |
+| `view_item` | `Analytics/TrackItemView`, `TicketList/TicketGate` | Product page opens; ticket gate opens (the modal *is* the ticket's detail view) |
+| `begin_checkout` | `useBuyProduct`, `useMembershipGate` | Just before the redirect to Stripe — for a product, a ticket, or a membership |
+| `purchase` | `Analytics/PurchaseTracker` | Stripe returns the buyer with a `session_id` that `/api/analytics/purchase` confirms as paid |
+
+`item_category` splits revenue three ways: **Produkt**, **Biljett**,
+**Medlemskap**. `item_variant` carries the product size or the screening venue.
+`transaction_id` is the Stripe session id, so a refresh of the thank-you page
+can't double-count (the tracker also remembers sent ids in `sessionStorage`).
+
+There is no cart in this shop — buying goes straight from item to Stripe — so
+`add_to_cart` is deliberately absent and the funnel reads
+view_item → begin_checkout → purchase.
+
+### Reports → Engagement → Events (custom)
+
+| Event | Meaning | Key params |
+| --- | --- | --- |
+| `sign_up` | Membership paid for and joined | `method` |
+| `ticket_gate_step` | Each step of the members-only gate — the drop-off funnel | `gate_step` (`choice`/`join`/`code`/`joined`/`already`/`disabled`), `item_id`, `item_name` |
+| `select_size` | A product size was picked, including sizes nobody buys | `item_id`, `item_variant` |
+| `trailer_open` | A trailer overlay was opened | `video_platform`, `video_id`, `video_title` |
+| `contact_email_copy` | Footer email copied — invisible to outbound-click tracking | `link_url` |
+| `page_not_found` | A 404 was rendered | `page_path`, `page_referrer` |
+| `exception` | A checkout, membership or network failure | `description` (e.g. `ticket_checkout:invalid_code`), `item_id` |
+
+Video playback (`video_start`, `video_progress`, `video_complete`) comes from
+Enhanced measurement: the YouTube embed URL sets `enablejsapi=1` for exactly
+that reason. Vimeo can't be instrumented by GA — `trailer_open` is the only
+signal there.
+
+## Implementation notes
+
+- `dataLayer` and `gtag` are defined by an inline script in the server-rendered
+  HTML, and only the gtag.js library itself loads `afterInteractive`. Without
+  that, the first effects on a page (`view_item`, `view_item_list`) run before
+  gtag exists and their events are dropped — measured, not theoretical.
+- `view_item_list` fires on render rather than on scroll. Impressions therefore
+  count "the list was on the page", and a block rendered twice for
+  responsiveness must still mount one tracker (see `Blocks/TicketList`).
+- There's no official Google npm package for GA4 on the web; gtag.js is the
+  integration. `@next/third-parties/google` was considered and skipped — it
+  covers only the script loader and a `dataLayer` push helper, both of which
+  are ~30 lines here.
+
+## One-time setup in the GA UI
+
+Code alone doesn't finish the job. In **Admin** for the property:
+
+1. **Data streams → the web stream → Enhanced measurement** — switch it on and
+   keep every sub-toggle enabled, especially *Page views → advanced settings →
+   page changes based on browser history events* (this site is a SPA) and
+   *Video engagement*.
+2. **Custom definitions → Custom dimensions** — register these event-scoped
+   params, otherwise they're collected but not reportable:
+   `gate_step`, `purchase_type`, `checkout_type`, `video_platform`,
+   `video_title`, `page_path`, `description`. (`item_category`, `item_variant`,
+   `item_list_name` are item-scoped and already built in.)
+3. **Events → Mark as key event** — at minimum `purchase` and `sign_up`;
+   `begin_checkout` if you want the funnel scored.
+4. **Data settings → Data retention** — raise from the default 2 months to 14
+   months, or explorations can't look back further.
+5. **Reports → Library** — publish the *Monetization* collection if it isn't
+   already; it's hidden by default on new properties.
+
+## Consent
+
+There is no consent banner on the site, and the tag currently fires for every
+visitor. GA4's cookies are not strictly necessary under GDPR/ePrivacy, so a
+Swedish-market site should gate this behind consent — Google Consent Mode v2
+with `analytics_storage: denied` by default, flipped on acceptance. Not
+implemented.

--- a/src/app/(site)/shop/products/[slug]/page.tsx
+++ b/src/app/(site)/shop/products/[slug]/page.tsx
@@ -17,6 +17,7 @@ import ProductPurchase, {
 } from '@/components/Blocks/ProductList/ProductPurchase';
 import ProductGallery from './ProductGallery';
 import JsonLd from '@/components/JsonLd';
+import TrackItemView from '@/components/Analytics/TrackItemView';
 import { formatPrice } from '@/lib/products/formatPrice';
 import { getSiteUrl } from '@/utils/siteUrl';
 import type {
@@ -130,6 +131,17 @@ export default async function ProductPage({
   return (
     <>
       <JsonLd data={productJsonLd} />
+      <TrackItemView
+        item={{
+          item_id: product._id,
+          item_name: product.title ?? 'Produkt',
+          item_category: 'Produkt',
+          price: product.price ?? undefined,
+          quantity: 1,
+          ...(initialSize ? { item_variant: initialSize } : {}),
+        }}
+        currency={product.currency}
+      />
       <Header />
       <main
         className='grid grid-cols-1 max-lg:pt-[22%] mt-[var(--header-height-mobile)] lg:mt-0 lg:col-span-10 lg:row-span-full lg:overflow-y-scroll lg:py-p-desktop'
@@ -154,6 +166,7 @@ export default async function ProductPage({
             {variants.length > 0 ? (
               <ProductPurchase
                 productId={product._id}
+                productTitle={product.title ?? 'Produkt'}
                 price={product.price ?? 0}
                 currency={product.currency}
                 variants={variants}

--- a/src/app/api/analytics/purchase/route.ts
+++ b/src/app/api/analytics/purchase/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+
+import { stripe } from '@/lib/stripe';
+import { clientIp, rateLimit } from '@/lib/rateLimit';
+
+export const runtime = 'nodejs';
+
+/**
+ * Resolves a Stripe Checkout session into a GA4 `purchase` payload for the
+ * browser to send. Only the buyer lands on the success URL with their own
+ * session id, and nothing personal (email, address) is returned — just what the
+ * Monetization reports need.
+ */
+export async function GET(request: Request) {
+  if (!rateLimit(`analytics-purchase:${clientIp(request)}`, 30, 60_000)) {
+    return NextResponse.json({ error: 'rate_limited' }, { status: 429 });
+  }
+
+  const sessionId = new URL(request.url).searchParams.get('session_id');
+  if (!sessionId?.startsWith('cs_')) {
+    return NextResponse.json({ error: 'invalid_session_id' }, { status: 400 });
+  }
+
+  let session;
+  try {
+    session = await stripe.checkout.sessions.retrieve(sessionId, {
+      expand: ['line_items'],
+    });
+  } catch {
+    return NextResponse.json({ error: 'session_not_found' }, { status: 404 });
+  }
+
+  // Abandoned or still-processing sessions aren't revenue yet.
+  if (session.payment_status !== 'paid') {
+    return NextResponse.json({ error: 'not_paid' }, { status: 409 });
+  }
+
+  const metadata = session.metadata ?? {};
+  const category =
+    metadata.type === 'membership'
+      ? 'Medlemskap'
+      : metadata.ticketId
+        ? 'Biljett'
+        : 'Produkt';
+  const itemId =
+    metadata.ticketId ?? metadata.productId ?? metadata.type ?? sessionId;
+
+  const currency = (session.currency ?? 'sek').toUpperCase();
+  const items = (session.line_items?.data ?? []).map((line, index) => ({
+    item_id: itemId,
+    item_name: line.description ?? category,
+    item_category: category,
+    ...(metadata.size ? { item_variant: metadata.size } : {}),
+    price: (line.amount_total ?? 0) / 100 / (line.quantity || 1),
+    quantity: line.quantity ?? 1,
+    index,
+  }));
+
+  return NextResponse.json({
+    // Stripe's session id is stable per order, so GA dedupes repeat sends.
+    transaction_id: session.id,
+    value: (session.amount_total ?? 0) / 100,
+    currency,
+    purchase_type: category,
+    items,
+  });
+}

--- a/src/app/api/membership/route.ts
+++ b/src/app/api/membership/route.ts
@@ -74,7 +74,9 @@ export async function POST(request: Request) {
   // On success, return to the page the user came from (the shop) with a flag so
   // the client can reopen that ticket's modal on the thank-you step — no more
   // standalone success page. Respect any existing query string on cancelPath.
-  const returnPath = `${cancelPath}${cancelPath.includes("?") ? "&" : "?"}membership=joined`;
+  // session_id lets the client report the join as a GA4 purchase (and sign_up)
+  // once Stripe confirms it; the ticket gate strips both flags after reading.
+  const returnPath = `${cancelPath}${cancelPath.includes("?") ? "&" : "?"}membership=joined&session_id={CHECKOUT_SESSION_ID}`;
 
   // The fee is configured in Settings → Membership (falls back to the default).
   const settings = await client.fetch(settingsQuery);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import { Lato, Oswald } from 'next/font/google';
 import '@/app/globals.css';
 import { ViewTransitions } from 'next-view-transitions';
 import { initViewportScale } from '@/lib/viewportScale';
+import GoogleAnalytics from '@/components/Analytics/GoogleAnalytics';
+import PurchaseTracker from '@/components/Analytics/PurchaseTracker';
 
 const oswald = Oswald({
   variable: '--font-oswald',
@@ -51,6 +53,8 @@ export default async function RootLayout({
           className={`grid lg:grid-cols-12 lg:grid-rows-6 lg:gap-x-p-desktop lg:h-screen lg:overflow-hidden antialiased ${lato.variable} ${oswald.variable}`}
         >
           {children}
+          <GoogleAnalytics />
+          <PurchaseTracker />
         </body>
       </html>
     </ViewTransitions>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,9 +1,12 @@
 import Header from '@/components/Header/Header';
 import { Link } from 'next-view-transitions';
 
+import TrackNotFound from '@/components/Analytics/TrackNotFound';
+
 export default function Custom404() {
   return (
     <>
+      <TrackNotFound />
       <Header />
       <main
         className='grid lg:col-span-10 lg:row-span-full lg:overflow-y-scroll lg:py-p-desktop'

--- a/src/components/Analytics/GoogleAnalytics.tsx
+++ b/src/components/Analytics/GoogleAnalytics.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Script from 'next/script';
+import { usePathname } from 'next/navigation';
+
+// Measurement ID is public — it ships in the page HTML either way.
+const GA_MEASUREMENT_ID = 'G-Q30CGRHEZN';
+
+// Only the live site reports: dev and Vercel previews stay out of the property.
+const enabled =
+  process.env.NODE_ENV === 'production' &&
+  process.env.NEXT_PUBLIC_VERCEL_ENV !== 'preview';
+
+// Runs in the server-rendered HTML, so window.gtag exists before hydration —
+// otherwise the first effects (view_item, view_item_list) call a gtag that
+// isn't there yet and their events are lost. Calls made before the library
+// finishes loading queue up in dataLayer and are processed on arrival.
+const bootstrap = `window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+window.gtag = gtag;
+gtag('js', new Date());
+gtag('config', '${GA_MEASUREMENT_ID}');`;
+
+/**
+ * Loads gtag.js site-wide. GA4's enhanced measurement picks up the App Router's
+ * history-based navigations, so page views need no per-route wiring here.
+ */
+const GoogleAnalytics = () => {
+  const pathname = usePathname();
+
+  // The Studio is editor traffic, not visitors.
+  if (!enabled || pathname.startsWith('/studio')) return null;
+
+  return (
+    <>
+      <script dangerouslySetInnerHTML={{ __html: bootstrap }} />
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy='afterInteractive'
+      />
+    </>
+  );
+};
+
+export default GoogleAnalytics;

--- a/src/components/Analytics/PurchaseTracker.tsx
+++ b/src/components/Analytics/PurchaseTracker.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { trackEvent } from '@/lib/analytics/gtag';
+
+const SENT_KEY = 'phmedia:ga-purchases';
+
+/** Session ids already reported, so a refresh doesn't double-count revenue. */
+const alreadySent = (id: string): boolean => {
+  try {
+    return (sessionStorage.getItem(SENT_KEY) ?? '').split(',').includes(id);
+  } catch {
+    return false;
+  }
+};
+
+const markSent = (id: string) => {
+  try {
+    const prev = sessionStorage.getItem(SENT_KEY);
+    sessionStorage.setItem(SENT_KEY, prev ? `${prev},${id}` : id);
+  } catch {
+    // Private mode — worst case the purchase is sent twice; GA dedupes on
+    // transaction_id.
+  }
+};
+
+/**
+ * Sends GA4 `purchase` wherever Stripe drops the buyer back with a
+ * `session_id`: /shop/success, /tickets/success, and the membership return URL.
+ * Mounted once in the root layout so no success page needs its own wiring.
+ *
+ * The id is read during render, not in the effect, because the ticket gate
+ * strips its return-params in a requestAnimationFrame that can land first.
+ */
+const PurchaseTracker = () => {
+  const [sessionId] = useState(() => {
+    if (typeof window === 'undefined') return null;
+    return new URLSearchParams(window.location.search).get('session_id');
+  });
+
+  useEffect(() => {
+    if (!sessionId?.startsWith('cs_') || alreadySent(sessionId)) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/analytics/purchase?session_id=${encodeURIComponent(sessionId)}`
+        );
+        if (!res.ok || cancelled) return;
+        const purchase = await res.json();
+        if (cancelled) return;
+
+        markSent(sessionId);
+        trackEvent('purchase', purchase);
+
+        // Joining the film club is a sign-up as well as a sale.
+        if (purchase.purchase_type === 'Medlemskap') {
+          trackEvent('sign_up', { method: 'filmklubben' });
+        }
+      } catch {
+        // Analytics must never break the thank-you page.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  return null;
+};
+
+export default PurchaseTracker;

--- a/src/components/Analytics/TrackItemView.tsx
+++ b/src/components/Analytics/TrackItemView.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { trackEcommerce, type AnalyticsItem } from '@/lib/analytics/gtag';
+
+type TrackItemViewProps = {
+  item: AnalyticsItem;
+  currency?: string | null;
+};
+
+/** Reports GA4 `view_item` for a product detail page. */
+const TrackItemView = ({ item, currency }: TrackItemViewProps) => {
+  useEffect(() => {
+    trackEcommerce('view_item', { items: [item], currency });
+    // Re-fire when the shopper view-transitions to another product.
+  }, [item, currency]);
+
+  return null;
+};
+
+export default TrackItemView;

--- a/src/components/Analytics/TrackListView.tsx
+++ b/src/components/Analytics/TrackListView.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { trackEcommerce, type AnalyticsItem } from '@/lib/analytics/gtag';
+
+type TrackListViewProps = {
+  /** Stable id, e.g. 'tickets' or 'shop'. */
+  listId: string;
+  listName: string;
+  items: AnalyticsItem[];
+  currency?: string | null;
+};
+
+/**
+ * Reports a GA4 `view_item_list` impression — the top of the Monetization
+ * funnel. Fired when the list renders rather than when it scrolls into view:
+ * blocks are server-rendered per page, so "rendered" is a straight answer, and
+ * a scroll-gated version would hang off a 1px marker element that's easy to
+ * break with a layout change.
+ */
+const TrackListView = ({
+  listId,
+  listName,
+  items,
+  currency,
+}: TrackListViewProps) => {
+  // Serialised so a re-render with an equivalent list doesn't re-report.
+  const signature = JSON.stringify(items);
+
+  useEffect(() => {
+    const listItems: AnalyticsItem[] = JSON.parse(signature);
+    if (listItems.length === 0) return;
+
+    trackEcommerce('view_item_list', {
+      items: listItems.map((item, index) => ({
+        ...item,
+        index,
+        item_list_id: listId,
+        item_list_name: listName,
+      })),
+      currency,
+      item_list_id: listId,
+      item_list_name: listName,
+      // Impressions aren't revenue; only purchase should carry a value.
+      value: 0,
+    });
+  }, [signature, listId, listName, currency]);
+
+  return null;
+};
+
+export default TrackListView;

--- a/src/components/Analytics/TrackNotFound.tsx
+++ b/src/components/Analytics/TrackNotFound.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { trackEvent } from '@/lib/analytics/gtag';
+
+/**
+ * Reports the URL behind a 404. GA counts the page view either way, but only
+ * this event tells them apart from real pages in the Engagement reports.
+ */
+const TrackNotFound = () => {
+  useEffect(() => {
+    trackEvent('page_not_found', {
+      page_location: window.location.href,
+      page_path: window.location.pathname,
+      page_referrer: document.referrer || undefined,
+    });
+  }, []);
+
+  return null;
+};
+
+export default TrackNotFound;

--- a/src/components/Blocks/ProductList/ProductGrid.tsx
+++ b/src/components/Blocks/ProductList/ProductGrid.tsx
@@ -8,6 +8,8 @@ import {
   useStaggeredGridReveal,
   type ColumnQuery,
 } from '@/hooks/useStaggeredGridReveal';
+import { trackEcommerce } from '@/lib/analytics/gtag';
+import { toProductItem } from './analyticsItem';
 
 type IProductGrid = {
   products: NonNullable<IProductListBlock['products']>;
@@ -39,11 +41,24 @@ const ProductGrid = ({ products, single }: IProductGrid) => {
       {products.map((product, index) => {
         if (!product || !('_id' in product)) return null;
 
+        // Click-through from the grid — GA4's step between impression and detail.
+        const trackSelect = () => {
+          const item = toProductItem(product);
+          if (!item) return;
+          trackEcommerce('select_item', {
+            items: [{ ...item, index, item_list_id: 'shop' }],
+            currency: 'currency' in product ? product.currency : null,
+            item_list_id: 'shop',
+            value: 0,
+          });
+        };
+
         return (
           <motion.div
             key={`${product._id}-${index}`}
             ref={setRef}
             data-index={index}
+            onClick={trackSelect}
             {...getItemProps(index)}
           >
             <ProductCard product={product} />

--- a/src/components/Blocks/ProductList/ProductPurchase.tsx
+++ b/src/components/Blocks/ProductList/ProductPurchase.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 
 import { formatPrice } from '@/lib/products/formatPrice';
+import { trackEvent } from '@/lib/analytics/gtag';
 import { dataAttr } from '@/sanity/lib/utils';
 import { useBuyProduct } from './useBuyProduct';
 
@@ -15,6 +16,8 @@ export type PurchaseVariant = {
 
 type ProductPurchaseProps = {
   productId: string;
+  /** Analytics only — the heading already renders the title. */
+  productTitle: string;
   price: number;
   currency: string | null;
   variants: PurchaseVariant[];
@@ -25,13 +28,18 @@ const isSoldOut = (v: PurchaseVariant) => (v.sold ?? 0) >= v.stock;
 
 export default function ProductPurchase({
   productId,
+  productTitle,
   price,
   currency,
   variants,
   initialSize,
 }: ProductPurchaseProps) {
   const [size, setSize] = useState(initialSize);
-  const { startCheckout, loading, error } = useBuyProduct();
+  const { startCheckout, loading, error } = useBuyProduct({
+    title: productTitle,
+    price,
+    currency,
+  });
 
   const selected = variants.find((v) => v.size === size) ?? variants[0] ?? null;
   const soldOut = selected ? isSoldOut(selected) : true;
@@ -43,6 +51,12 @@ export default function ProductPurchase({
 
   function selectSize(next: string) {
     setSize(next);
+    // Which sizes shoppers reach for, including ones they never buy.
+    trackEvent('select_size', {
+      item_id: productId,
+      item_name: productTitle,
+      item_variant: next,
+    });
     // Reflect the choice in the URL so it's shareable/bookmarkable (?size=M).
     const url = new URL(window.location.href);
     url.searchParams.set('size', next);

--- a/src/components/Blocks/ProductList/analyticsItem.ts
+++ b/src/components/Blocks/ProductList/analyticsItem.ts
@@ -1,0 +1,16 @@
+import type { AnalyticsItem } from '@/lib/analytics/gtag';
+import type { IProductListBlock } from '.';
+
+type ProductRef = NonNullable<IProductListBlock['products']>[number];
+
+/** Shared product → GA4 item mapping, so every event describes a product the same way. */
+export const toProductItem = (product: ProductRef): AnalyticsItem | null => {
+  if (!product || !('_id' in product)) return null;
+  return {
+    item_id: product._id,
+    item_name: product.title ?? 'Produkt',
+    item_category: 'Produkt',
+    price: typeof product.price === 'number' ? product.price : undefined,
+    quantity: 1,
+  };
+};

--- a/src/components/Blocks/ProductList/index.tsx
+++ b/src/components/Blocks/ProductList/index.tsx
@@ -2,7 +2,9 @@ import type {
   FetchHomeResult,
   FetchPageResult,
 } from '../../../../sanity.types';
+import TrackListView from '@/components/Analytics/TrackListView';
 import ProductGrid from './ProductGrid';
+import { toProductItem } from './analyticsItem';
 
 export type IProductListBlock = Extract<
   NonNullable<
@@ -19,11 +21,23 @@ const ProductList = (block: IProductListBlock) => {
 
   const title = block.title?.trim();
 
+  const trackedItems = products
+    .map(toProductItem)
+    .filter((item) => item !== null);
+  const currency = products.find((p) => p && 'currency' in p)?.currency ?? null;
+
   return (
     <section
       key={block._key || 'productList'}
       className='page-x-spacing flex flex-col gap-6 lg:gap-8'
     >
+      <TrackListView
+        listId='shop'
+        listName={title || 'Produkter'}
+        items={trackedItems}
+        currency={currency}
+      />
+
       {title ? (
         <h2 className='text-h-67 lg:text-h-37 !leading-[1] uppercase'>
           {title}

--- a/src/components/Blocks/ProductList/useBuyProduct.ts
+++ b/src/components/Blocks/ProductList/useBuyProduct.ts
@@ -2,8 +2,21 @@
 
 import { useEffect, useState } from 'react';
 
+import {
+  trackEcommerce,
+  trackException,
+  type AnalyticsItem,
+} from '@/lib/analytics/gtag';
+
+/** What GA4 should report for the product being bought (title, price, size). */
+export type CheckoutItem = {
+  title: string;
+  price: number;
+  currency: string | null;
+};
+
 /** Shared Stripe-checkout logic for a product size, used by the buy button. */
-export function useBuyProduct() {
+export function useBuyProduct(item?: CheckoutItem) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -39,10 +52,29 @@ export function useBuyProduct() {
           const detail = json?.message ? ` — ${json.message}` : '';
           setError(`Error: ${code}${detail}`);
         }
+        trackException(`product_checkout:${json?.error ?? res.status}`, {
+          item_id: productId,
+          item_variant: size,
+        });
         setLoading(false);
         return;
       }
       if (json.url) {
+        // Fired before the redirect so gtag's beacon leaves with the unload.
+        if (item) {
+          const gaItem: AnalyticsItem = {
+            item_id: productId,
+            item_name: item.title,
+            item_category: 'Produkt',
+            item_variant: size,
+            price: item.price,
+            quantity: 1,
+          };
+          trackEcommerce('begin_checkout', {
+            items: [gaItem],
+            currency: item.currency,
+          });
+        }
         // Stay in loading through the redirect (no reset here).
         window.location.assign(json.url);
         return;
@@ -51,6 +83,7 @@ export function useBuyProduct() {
       setLoading(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Request failed');
+      trackException('product_checkout:network', { item_id: productId });
       setLoading(false);
     }
   }

--- a/src/components/Blocks/TicketList/Ticket.tsx
+++ b/src/components/Blocks/TicketList/Ticket.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { urlFor } from '@/sanity/lib/image';
 import { BuyTicketCard } from './BuyTicketCard';
 import { TicketGate } from './TicketGate';
+import { toTicketItem } from './analyticsItem';
 import type { ITicketListBlock, TicketLabels } from '.';
 
 type TicketData = NonNullable<ITicketListBlock['tickets']>[number];
@@ -100,6 +101,8 @@ const Ticket = ({
       ticketId={ticket._id}
       contactEmail={contactEmail}
       membershipFeeLabel={membershipFeeLabel}
+      item={toTicketItem(ticket)}
+      currency={'currency' in ticket ? ticket.currency : null}
     >
       <div className='lg:flex lg:items-stretch'>
         {/* Mobile: the entire card opens the members-only gate */}

--- a/src/components/Blocks/TicketList/TicketGate.tsx
+++ b/src/components/Blocks/TicketList/TicketGate.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { AnimatePresence } from "framer-motion";
 
+import { trackEcommerce, type AnalyticsItem } from "@/lib/analytics/gtag";
 import { TicketGateModal } from "./TicketGateModal";
 
 // Lets the buy button and the whole-card trigger open one shared gate modal.
@@ -22,6 +23,9 @@ type TicketGateProps = {
   ticketId: string;
   contactEmail?: string | null;
   membershipFeeLabel?: string;
+  /** GA4 item for this screening; null when the ticket ref is unresolved. */
+  item?: AnalyticsItem | null;
+  currency?: string | null;
   children: ReactNode;
 };
 
@@ -39,6 +43,8 @@ export function TicketGate({
   ticketId,
   contactEmail,
   membershipFeeLabel,
+  item,
+  currency,
   children,
 }: TicketGateProps) {
   const [open, setOpen] = useState(false);
@@ -75,6 +81,8 @@ export function TicketGate({
         // ignore
       }
       params.delete("membership");
+      // PurchaseTracker reads session_id during render, so it's safe to drop.
+      params.delete("session_id");
       const qs = params.toString();
       window.history.replaceState(
         null,
@@ -87,6 +95,18 @@ export function TicketGate({
 
   // Manual opens (clicking a ticket) always start fresh on the choice step.
   function openFresh() {
+    // Clicking the card is both the click-through and the detail view — there
+    // is no separate ticket page, the modal is the product detail.
+    if (item) {
+      trackEcommerce("select_item", {
+        items: [{ ...item, item_list_id: "tickets" }],
+        currency,
+        item_list_id: "tickets",
+        item_list_name: "Visningar",
+        value: 0,
+      });
+      trackEcommerce("view_item", { items: [item], currency });
+    }
     setInitialView("choice");
     setPrefillEmail("");
     setOpen(true);
@@ -100,6 +120,8 @@ export function TicketGate({
           <TicketGateModal
             key="gate"
             ticketId={ticketId}
+            item={item}
+            currency={currency}
             contactEmail={contactEmail}
             membershipFeeLabel={membershipFeeLabel}
             initialView={initialView}

--- a/src/components/Blocks/TicketList/TicketGateModal.tsx
+++ b/src/components/Blocks/TicketList/TicketGateModal.tsx
@@ -4,12 +4,16 @@ import { useEffect, useState, type FormEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, easeInOut } from 'framer-motion';
 
+import { trackEvent, type AnalyticsItem } from '@/lib/analytics/gtag';
 import { useMembershipGate } from './useMembershipGate';
 
 type GateView = 'choice' | 'join' | 'code' | 'joined' | 'already' | 'disabled';
 
 type TicketGateModalProps = {
   ticketId: string;
+  /** GA4 item for the screening behind this gate. */
+  item?: AnalyticsItem | null;
+  currency?: string | null;
   // Footer contact email, shown when a member's access has been revoked.
   contactEmail?: string | null;
   // Membership fee label (e.g. "49 kr") from Settings, shown on the join step.
@@ -45,6 +49,8 @@ function Spinner() {
 
 export function TicketGateModal({
   ticketId,
+  item,
+  currency,
   contactEmail,
   membershipFeeLabel,
   initialView = 'choice',
@@ -57,7 +63,7 @@ export function TicketGateModal({
   const [email, setEmail] = useState(initialEmail);
   const [code, setCode] = useState('');
   const { loading, error, setError, checkOrJoin, buyTicket } =
-    useMembershipGate(ticketId);
+    useMembershipGate(ticketId, item, currency);
 
   // Lock body scroll and wire Escape-to-close while mounted (i.e. open).
   useEffect(() => {
@@ -74,9 +80,16 @@ export function TicketGateModal({
   }, [onClose]);
 
   // Switch step and clear any stale error from the previous step.
+  // Each step is reported so the gate's drop-off is visible in GA (Engagement →
+  // Events, or as a funnel exploration over `gate_step`).
   function goTo(next: GateView) {
     setError(null);
     setView(next);
+    trackEvent('ticket_gate_step', {
+      gate_step: next,
+      item_id: ticketId,
+      item_name: item?.item_name,
+    });
   }
 
   async function handleJoinSubmit(e: FormEvent) {

--- a/src/components/Blocks/TicketList/analyticsItem.ts
+++ b/src/components/Blocks/TicketList/analyticsItem.ts
@@ -1,0 +1,18 @@
+import type { AnalyticsItem } from '@/lib/analytics/gtag';
+import type { ITicketListBlock } from '.';
+
+type TicketRef = NonNullable<ITicketListBlock['tickets']>[number];
+
+/** Shared ticket → GA4 item mapping, used by every step of the ticket funnel. */
+export const toTicketItem = (ticket: TicketRef): AnalyticsItem | null => {
+  if (!ticket || !('_id' in ticket)) return null;
+  return {
+    item_id: ticket._id,
+    item_name: ticket.title ?? 'Biljett',
+    item_category: 'Biljett',
+    // The screening venue is the closest thing a ticket has to a variant.
+    ...(ticket.venue ? { item_variant: ticket.venue } : {}),
+    price: typeof ticket.price === 'number' ? ticket.price : undefined,
+    quantity: 1,
+  };
+};

--- a/src/components/Blocks/TicketList/index.tsx
+++ b/src/components/Blocks/TicketList/index.tsx
@@ -6,6 +6,8 @@ import type {
 import { sanityFetch } from '@/sanity/lib/live';
 import { fetchFooter, settingsQuery } from '@/sanity/lib/queries';
 import { formatMembershipFee } from '@/lib/members/membershipFee';
+import TrackListView from '@/components/Analytics/TrackListView';
+import { toTicketItem } from './analyticsItem';
 import Ticket from './Ticket';
 import { TicketCarousel } from './TicketCarousel';
 import { TicketColumn } from './TicketColumn';
@@ -57,6 +59,20 @@ const TicketList = async (block: ITicketListProps) => {
   // Bottom spacing defaults to true when unset (40px mobile / 80px desktop).
   const bottomSpacingClass = block.bottomSpacing !== false ? 'mb-20' : '';
 
+  // Rendered exactly once per block — the solo-/shop layout renders the cards
+  // twice (mobile carousel + desktop column) and both mount, so a tracker in
+  // each branch would report the impression twice.
+  const trackedItems = tickets.map(toTicketItem).filter((item) => item !== null);
+  const currency = tickets.find((t) => t && 'currency' in t)?.currency ?? null;
+  const listTracker = (
+    <TrackListView
+      listId='tickets'
+      listName='Visningar'
+      items={trackedItems}
+      currency={currency}
+    />
+  );
+
   const ticketCards = tickets.map((ticket, i) => (
     <Ticket
       key={('_id' in ticket && ticket._id) || i}
@@ -75,6 +91,7 @@ const TicketList = async (block: ITicketListProps) => {
         className={`page-x-spacing flex flex-col gap-2.5 h-fit uppercase lg:gap-10 ${bottomSpacingClass}`}
         data-sanity-edit-target
       >
+        {listTracker}
         {sectionTitle ? (
           <h2 className='text-h-67 lg:text-h-37 !leading-[1]'>{sectionTitle}</h2>
         ) : null}
@@ -90,12 +107,19 @@ const TicketList = async (block: ITicketListProps) => {
     </TicketCarousel>
   );
 
-  if (!columnLayout) return carousel;
+  if (!columnLayout)
+    return (
+      <>
+        {listTracker}
+        {carousel}
+      </>
+    );
 
   // Solo /shop block: keep the carousel on mobile, but stack the big cards as a
   // vertical column on desktop so the otherwise-empty page fills out.
   return (
     <>
+      {listTracker}
       <div className='lg:hidden'>{carousel}</div>
       <section
         key={block._key || 'ticketList'}

--- a/src/components/Blocks/TicketList/useMembershipGate.ts
+++ b/src/components/Blocks/TicketList/useMembershipGate.ts
@@ -2,6 +2,12 @@
 
 import { useEffect, useState } from "react";
 
+import {
+  trackEcommerce,
+  trackException,
+  type AnalyticsItem,
+} from "@/lib/analytics/gtag";
+
 // Swedish, user-facing messages for the API error envelope.
 function membershipErrorMessage(code: unknown, status: number): string {
   switch (code) {
@@ -44,7 +50,11 @@ export type JoinOutcome = "is_member" | "redirecting" | "disabled" | null;
  *    if no → redirect to the 29 kr membership Stripe Checkout.
  *  - buyTicket: validate member + access code, then redirect to ticket Checkout.
  */
-export function useMembershipGate(ticketId: string) {
+export function useMembershipGate(
+  ticketId: string,
+  item?: AnalyticsItem | null,
+  currency?: string | null,
+) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -81,6 +91,9 @@ export function useMembershipGate(ticketId: string) {
       const json = await res.json();
       if (!res.ok) {
         setLoading(false);
+        trackException(`membership:${json?.error ?? res.status}`, {
+          item_id: ticketId,
+        });
         // Revoked members get a dedicated support view, not an inline error.
         if (json?.error === "membership_disabled") return "disabled";
         setError(membershipErrorMessage(json?.error, res.status));
@@ -103,6 +116,21 @@ export function useMembershipGate(ticketId: string) {
         } catch {
           // Ignore storage failures (private mode, etc.) — the join still works.
         }
+        // Fired before the redirect so gtag's beacon leaves with the unload.
+        // The fee lives in Sanity Settings, so the sale value is filled in by
+        // the `purchase` event on the way back from Stripe.
+        trackEcommerce("begin_checkout", {
+          items: [
+            {
+              item_id: "membership",
+              item_name: "Medlemskap Filmklubben",
+              item_category: "Medlemskap",
+              quantity: 1,
+            },
+          ],
+          currency,
+          checkout_type: "membership",
+        });
         // Stay in loading through the redirect (no reset here).
         window.location.assign(json.url);
         return "redirecting";
@@ -112,6 +140,7 @@ export function useMembershipGate(ticketId: string) {
       return null;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Request failed");
+      trackException("membership:network", { item_id: ticketId });
       setLoading(false);
       return null;
     }
@@ -140,6 +169,10 @@ export function useMembershipGate(ticketId: string) {
       const json = await res.json();
       if (!res.ok) {
         setLoading(false);
+        trackException(`ticket_checkout:${json?.error ?? res.status}`, {
+          item_id: ticketId,
+          item_name: item?.item_name,
+        });
         // Revoked members get a dedicated support view, not an inline error.
         if (json?.error !== "membership_disabled") {
           setError(checkoutErrorMessage(json?.error, res.status));
@@ -147,6 +180,14 @@ export function useMembershipGate(ticketId: string) {
         return json?.error ?? "error";
       }
       if (json.url) {
+        // Fired before the redirect so gtag's beacon leaves with the unload.
+        if (item) {
+          trackEcommerce("begin_checkout", {
+            items: [item],
+            currency,
+            checkout_type: "ticket",
+          });
+        }
         window.location.assign(json.url);
         return null;
       }
@@ -155,6 +196,7 @@ export function useMembershipGate(ticketId: string) {
       return "no_url";
     } catch (err) {
       setError(err instanceof Error ? err.message : "Request failed");
+      trackException("ticket_checkout:network", { item_id: ticketId });
       setLoading(false);
       return "network";
     }

--- a/src/components/Footer/ClickableEmail.tsx
+++ b/src/components/Footer/ClickableEmail.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState } from 'react';
 
+import { trackEvent } from '@/lib/analytics/gtag';
+
 interface ClickableEmailProps {
   email: string;
 }
@@ -11,6 +13,10 @@ const ClickableEmail = ({ email }: ClickableEmailProps) => {
 
   const handleEmailClick = async () => {
     if (!email) return;
+
+    // Contact intent — GA4's automatic outbound-click tracking never sees this,
+    // since copying the address isn't a navigation.
+    trackEvent('contact_email_copy', { link_url: `mailto:${email}` });
 
     // Check if clipboard API is available
     if (!navigator?.clipboard?.writeText) {

--- a/src/components/TrailerOverlay/TrailerOverlay.tsx
+++ b/src/components/TrailerOverlay/TrailerOverlay.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { TrailerType } from '../../../sanity.types';
 import VideoOverlay from '../VideoOverlay/VideoOverlay';
 import { extractVideoInfo } from '../VideoOverlay/videoUtils';
+import { trackEvent } from '@/lib/analytics/gtag';
 
 type ITrailerOverlay = {
   trailer: TrailerType;
@@ -18,6 +19,13 @@ const TrailerOverlay = ({ trailer, triggerIcon }: ITrailerOverlay) => {
   const openOverlay = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    // Playback itself is measured by GA4 for YouTube embeds; this covers the
+    // open (and is the only signal for Vimeo, which GA4 can't instrument).
+    trackEvent('trailer_open', {
+      video_platform: platform,
+      video_id: videoId,
+      video_title: trailer.trailerLinkLabel ?? undefined,
+    });
     setIsOpen(true);
   };
   const closeOverlay = () => setIsOpen(false);

--- a/src/components/VideoOverlay/videoUtils.ts
+++ b/src/components/VideoOverlay/videoUtils.ts
@@ -26,7 +26,9 @@ export const extractVideoInfo = (url: string): VideoInfo => {
 // Build the autoplay embed URL for a detected platform/id pair.
 export const buildEmbedUrl = (platform: VideoPlatform, id: string): string => {
   if (platform === 'youtube') {
-    return `https://www.youtube.com/embed/${id}?autoplay=1`;
+    // enablejsapi=1 is what lets GA4's enhanced measurement report
+    // video_start / video_progress / video_complete for the embed.
+    return `https://www.youtube.com/embed/${id}?autoplay=1&enablejsapi=1`;
   }
   return `https://player.vimeo.com/video/${id}?autoplay=1`;
 };

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -1,0 +1,79 @@
+/**
+ * Thin gtag.js wrapper. Every call is a no-op when GA hasn't loaded (dev,
+ * previews, ad blockers), so callers never need to guard.
+ *
+ * Event names follow GA4's recommended set wherever one exists — that's what
+ * makes them land in the built-in reports (Monetization, Engagement) instead of
+ * sitting as unmapped custom events. See docs/analytics.md for the mapping and
+ * the custom dimensions that need registering in the GA UI.
+ */
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+    dataLayer?: unknown[];
+  }
+}
+
+/** GA4 item shape (ecommerce events). */
+export type AnalyticsItem = {
+  item_id: string;
+  item_name: string;
+  /** 'Biljett' | 'Produkt' | 'Medlemskap' — groups revenue in Monetization. */
+  item_category?: string;
+  /** Size for products, venue for tickets. */
+  item_variant?: string;
+  price?: number;
+  quantity?: number;
+  index?: number;
+  item_list_id?: string;
+  item_list_name?: string;
+};
+
+export type EventParams = Record<string, unknown>;
+
+/**
+ * Fire any GA4 event. Falls back to queueing in dataLayer if gtag itself hasn't
+ * been defined yet (blocked script, unexpected ordering) so no event is lost;
+ * with no GA at all the queue is simply never drained.
+ */
+export const trackEvent = (name: string, params: EventParams = {}) => {
+  if (typeof window === 'undefined') return;
+  if (window.gtag) {
+    window.gtag('event', name, params);
+    return;
+  }
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push(['event', name, params]);
+};
+
+/** Fire a GA4 ecommerce event; `value` defaults to the sum of the items. */
+export const trackEcommerce = (
+  name: string,
+  {
+    items,
+    currency,
+    value,
+    ...params
+  }: { items: AnalyticsItem[]; currency?: string | null; value?: number } & EventParams
+) => {
+  trackEvent(name, {
+    currency: (currency ?? 'SEK').toUpperCase(),
+    value: value ?? itemsValue(items),
+    items,
+    ...params,
+  });
+};
+
+/** Sum of price × quantity across items, rounded to 2 decimals. */
+export const itemsValue = (items: AnalyticsItem[]): number =>
+  Math.round(
+    items.reduce((sum, i) => sum + (i.price ?? 0) * (i.quantity ?? 1), 0) * 100
+  ) / 100;
+
+/**
+ * Failed checkouts, invalid codes, network errors. `exception` is GA4's
+ * recommended name, so these surface without extra reporting setup.
+ */
+export const trackException = (description: string, context?: EventParams) =>
+  trackEvent('exception', { description, fatal: false, ...context });


### PR DESCRIPTION
Load gtag.js (G-Q30CGRHEZN) site-wide from the root layout, reporting only from the live site — dev, Vercel previews and /studio stay out of the property. The bootstrap runs inline in the server-rendered HTML so window.gtag exists before hydration; loading it afterInteractive means the first effects on a page fire into an undefined gtag and lose their events.

Instrument the full commerce funnel with GA4's recommended event names, so it populates the built-in Monetization reports rather than landing as unmapped custom events: view_item_list, select_item, view_item, begin_checkout and purchase, across products, tickets and membership. Revenue splits on item_category (Produkt/Biljett/Medlemskap) and item_variant carries the product size or screening venue. There is no cart here, so add_to_cart is deliberately absent.

purchase is resolved server-side: /api/analytics/purchase looks the Stripe session up, refuses anything not paid, and returns amounts and line names only — no email or address. PurchaseTracker sits in the root layout and reports whatever session_id Stripe returns with, covering both success pages and the membership return without per-page wiring; sends are recorded in sessionStorage and keyed on the Stripe session id so a refresh cannot double-count revenue. The membership success_url now carries session_id so joining is captured as revenue, not just a sign-up.

Beyond commerce: sign_up, the ticket gate's step-by-step drop-off, select_size, trailer_open, contact_email_copy, page_not_found, and exception for every checkout/membership/network failure. YouTube embeds get enablejsapi=1, without which GA4 cannot measure video engagement at all.

view_item_list fires on render rather than on scroll — blocks are server-rendered per page, and a scroll-gated version hangs off a 1px marker element that a layout change quietly breaks. A block rendered twice for responsiveness must therefore mount a single tracker.

docs/analytics.md maps every event to the report it lands in and lists the one-time GA console setup — custom dimensions, key events, enhanced measurement toggles, data retention — without which the custom params are collected but not reportable. Consent Mode is not implemented; the tag currently fires for every visitor.